### PR TITLE
Fix unreliable ConcurrentModificationException detection in IgniteToStringBuilder

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/tostring/IgniteToStringBuilder.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/tostring/IgniteToStringBuilder.java
@@ -1515,8 +1515,17 @@ public class IgniteToStringBuilder {
         int cnt = 0;
         boolean needHandleOverflow = true;
 
-        Iterator<Map.Entry<K, V>> iter = map.entrySet().iterator();
         int mapSize = map.size();
+
+        Iterator<Map.Entry<K, V>> iter;
+        try {
+            iter = map.entrySet().iterator();
+        } catch (ConcurrentModificationException e) {
+            handleConcurrentModification(buf, cnt, mapSize);
+
+            buf.app('}');
+            return;
+        }
 
         while (iter.hasNext()) {
             Object key;


### PR DESCRIPTION
The test code itself is acceptable. The issue arises because the `IgniteToStringBuilder`'s `addMap` method attempts to create an iterator over a map that the test is concurrently modifying. While the `addMap` method does check for ConcurrentModificationException when getting the values **out** of the iterator, it does not check for the exception when **creating** the iterator itself.

Thus, the solution is to wrap the creation of the iterator in a try-catch that will return early if a ConcurrentModificationException occurs.

The reason that the exception happens when using NonDex is explained in [NonDex's documentation for `HashMap`](https://github.com/TestingResearchIllinois/NonDex/blob/c31646fe48ae6f05d1b13128f6f9363060b7ee05/nondex-core/src/main/java/java/util/HashMap.java#L102-L109):

```
 * <p>The iterators returned by all of this class's "collection view methods"
 * are <i>fail-fast</i>: if the map is structurally modified at any time after
 * the iterator is created, in any way except through the iterator's own
 * <tt>remove</tt> method, the iterator will throw a
 * {@link ConcurrentModificationException}.  Thus, in the face of concurrent
 * modification, the iterator fails quickly and cleanly, rather than risking
 * arbitrary, non-deterministic behavior at an undetermined time in the
 * future.
```

The actual error is thrown on [these lines](https://github.com/TestingResearchIllinois/NonDex/blob/c31646fe48ae6f05d1b13128f6f9363060b7ee05/nondex-core/src/main/java/java/util/HashMap.java#L1440-L1441) of the NonDex source code, which check to see if any modification has been made, and if so, throw a `ConcurrentModificationException`.

The test that was originally found to be flaky was `org.apache.ignite.internal.tostring.IgniteToStringBuilderSelfTest.testToStringCheckConcurrentModificationExceptionFromMap`, in `modules/core`, on git commit `a1aa7fd4e2398c72827777ec5417d67915ff4da3`.